### PR TITLE
Retry Logic and Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ var queue = new Queue('my_queue_name', function process(item, done) {
   });
 });
 
-queue.on('success', function(item, res) {
+queue.on('processed', function(err, res, item) {
+  if (err) {
+    return console.warn('error processing %O: %O... will retry', item, err);
+  }
   console.log('successfully sent %O with response %O', item, res);
 });
 

--- a/README.md
+++ b/README.md
@@ -87,21 +87,18 @@ queue.stop();
 
 ## Emitter
 
-You can listen for `success` and `error` events, one of which is emitted with each invocation of the `processFunc`. If a message is discarded entirely because it does not pass your `shouldRetry` logic upon attempted re-enqueuing, the queue will emit a `discard` event.
+You can listen for `processed` events, of which is emitted with each invocation of the `processFunc` and passed any error, response provided along with the item itself. 
 
-### `success` (processed successfully)
+If a message is discarded entirely because it does not pass your `shouldRetry` logic upon attempted re-enqueuing, the queue will emit a `discard` event.
 
-```javascript
-queue.on('success', function(item, res) {
-  console.log('successfully flushed: %O', res);
-})
-```
-
-### `error` (error in processing)
+### `processed` (processed )
 
 ```javascript
-queue.on('error', function(item, error) {
-  console.warn('error processing %O: %O... will retry', item, error);
+queue.on('processed', function(err, res, item) {
+  if (err) {
+    console.warn('error processing %O: %O... will retry', item, err);
+  } 
+  console.log('successfully flushed %O: %O', item, res);
 })
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -185,7 +185,6 @@ Queue.prototype._processHead = function() {
         delete inProgress[id];
         store.inProgress.set(inProgress);
         self.emit('processed', err, res, el.item);
-        debug('processing AF', err, res, el.item);
         if (err) {
           self.requeue(el.item, el.attemptNumber + 1, err);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -184,12 +184,9 @@ Queue.prototype._processHead = function() {
         var inProgress = store.inProgress.get();
         delete inProgress[id];
         store.inProgress.set(inProgress);
-
+        self.emit('processed', err, res, el.item);
         if (err) {
-          self.emit('error', el.item, err);
           self.requeue(el.item, el.attemptNumber + 1, err);
-        } else {
-          self.emit('success', el.item, res);
         }
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ var store = require('./store');
 var each = require('@ndhoule/each');
 var Schedule = require('./schedule');
 var debug = require('debug')('localstorage-retry');
+var Emitter = require('component-emitter');
 
 // Some browsers don't support Function.prototype.bind, so just including a simplified version here
 function bind(func, obj) {
@@ -17,7 +18,8 @@ function bind(func, obj) {
  * @callback processFunc
  * @param {Mixed} item The item added to the queue to process
  * @param {Function} done A function to call when processing is completed.
- *   Takes an optional error parameter if the processing failed
+ *   @param {Error} Optional error parameter if the processing failed
+ *   @param {Response} Optional response parameter to emit for async handling
  */
 
 /**
@@ -57,6 +59,12 @@ function Queue(name, fn) {
 }
 
 /**
+ * Mix in event emitter
+ */
+
+Emitter(Queue.prototype);
+
+/**
  * Starts processing the queue
  */
 Queue.prototype.start = function() {
@@ -75,6 +83,18 @@ Queue.prototype.start = function() {
 Queue.prototype.stop = function() {
   this._schedule.cancelAll();
   this._running = false;
+};
+
+/**
+ * Decides whether to retry. Overridable.
+ *
+ * @param {Object} item The item being processed
+ * @param {Number} attemptNumber The attemptNumber (1 for first retry)
+ * @param {Error} error The error from previous attempt, if there was one
+ * @return {Boolean} Whether to requeue the message
+ */
+Queue.prototype.shouldRetry = function() {
+  return true;
 };
 
 /**
@@ -105,14 +125,19 @@ Queue.prototype.addItem = function(item) {
  *
  * @param {Mixed} item The item to retry
  * @param {Number} attemptNumber The attempt number (1 for first retry)
+ * @param {Error} [error] The error from previous attempt, if there was one
  */
-Queue.prototype.requeue = function(item, attemptNumber) {
+Queue.prototype.requeue = function(item, attemptNumber, error) {
   var delay = Math.min(this.getDelay(attemptNumber), this.timeouts.MAX_QUEUE_DELAY);
-  this._enqueue({
-    item: item,
-    attemptNumber: attemptNumber,
-    time: this._schedule.now() + delay
-  });
+  if (this.shouldRetry(item, attemptNumber, error)) {
+    this._enqueue({
+      item: item,
+      attemptNumber: attemptNumber,
+      time: this._schedule.now() + delay
+    });
+  } else {
+    this.emit('discard', item, attemptNumber);
+  }
 };
 
 Queue.prototype._enqueue = function(entry) {
@@ -155,13 +180,16 @@ Queue.prototype._processHead = function() {
 
     toRun.push({
       item: el.item,
-      done: function handle(err) {
+      done: function handle(err, res) {
         var inProgress = store.inProgress.get();
         delete inProgress[id];
         store.inProgress.set(inProgress);
 
         if (err) {
-          self.requeue(el.item, el.attemptNumber + 1);
+          self.emit('error', el.item, err);
+          self.requeue(el.item, el.attemptNumber + 1, err);
+        } else {
+          self.emit('success', el.item, res);
         }
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -185,6 +185,7 @@ Queue.prototype._processHead = function() {
         delete inProgress[id];
         store.inProgress.set(inProgress);
         self.emit('processed', err, res, el.item);
+        debug('processing AF', err, res, el.item);
         if (err) {
           self.requeue(el.item, el.attemptNumber + 1, err);
         }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@ndhoule/each": "^2.0.1",
     "@ndhoule/keys": "^2.0.0",
+    "component-emitter": "^1.2.1",
     "debug": "^0.7.4",
     "json3": "^3.3.2",
     "uuid": "^3.0.1"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -215,8 +215,8 @@ describe('events', function() {
     };
     queue.on('processed', function(err, res, item) {
       if (err) done(err);
-      assert(item.a === 'b');
-      assert(res.text === 'ok');
+      assert.equal(item.a, 'b');
+      assert.equal(res.text, 'ok');
       done();
     });
     queue.start();
@@ -229,8 +229,8 @@ describe('events', function() {
     };
 
     queue.on('processed', function(err, res, item) {
-      assert(item.a === 'c');
-      assert(err && err.message === 'fail');
+      assert.equal(item.a, 'c');
+      assert.equal(err && err.message, 'fail');
       done();
     });
 
@@ -246,8 +246,8 @@ describe('events', function() {
       return attemptNumber < 2;
     };
     queue.on('discard', function(item, attempts) {
-      assert(item.a === 'b');
-      assert(attempts === 2);
+      assert.equal(item.a, 'b');
+      assert.equal(attempts, 2);
       done();
     });
     queue.start();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,6 +77,40 @@ describe('Queue', function() {
     assert(queue.fn.calledWith('b'));
   });
 
+  it('should respect shouldRetry', function() {
+    queue.shouldRetry = function(_, attemptNumber) {
+      if (attemptNumber > 2) return false;
+      return true;
+    };
+    // Fail
+    queue.fn = sinon.spy(function(_, cb) {
+      return cb(new Error('no'));
+    });
+    queue.start();
+
+    // over maxattempts
+    queue.requeue('a', 3);
+    clock.tick(queue.getDelay(3));
+    assert(queue.fn.notCalled);
+
+    queue.fn.reset();
+
+    queue.requeue('a', 2);
+    clock.tick(queue.getDelay(2));
+    assert(queue.fn.calledOnce);
+
+    // logic based on item state (eg. could be msg timestamp field)
+    queue.shouldRetry = function(item) {
+      if (item.shouldRetry === false) return false;
+      return true;
+    };
+
+    queue.fn.reset();
+    queue.requeue({ shouldRetry: false }, 1);
+    clock.tick(queue.getDelay(1));
+    assert(queue.fn.notCalled);
+  });
+
   it('should take over a queued task if a queue is abandoned', function() {
     // set up a fake queue
     var fakeQueue = store('test', 'fake-id');
@@ -163,6 +197,65 @@ describe('Queue', function() {
   });
 });
 
+describe('events', function() {
+  var queue;
+  beforeEach(function() {
+    queue = new Queue('events', function(_, cb) {
+      cb();
+    });
+  });
+
+  afterEach(function() {
+    queue.stop();
+  });
+
+  it('should emit item and res in success events', function(done) {
+    queue.fn = function(item, cb) {
+      cb(null, { text: 'ok' });
+    };
+    queue.on('success', function(item, res) {
+      assert(item.a === 'b');
+      assert(res.text === 'ok');
+      done();
+    });
+    queue.start();
+    queue.addItem({ a: 'b' });
+  });
+
+  it('should emit error events with item and error', function(done) {
+    queue.fn = function(item, cb) {
+      cb(new Error('fail'));
+    };
+    queue.on('error', function(item, error) {
+      try {
+        assert(item.a === 'c');
+        assert(error.message === 'fail');
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+    queue.start();
+    queue.addItem({ a: 'c' });
+  });
+
+  it('should emit discard if the message fails shouldRetry', function(done) {
+    queue.fn = function(item, cb) {
+      cb(new Error('no'));
+    };
+    queue.shouldRetry = function(item, attemptNumber) {
+      return attemptNumber < 2;
+    };
+    queue.on('discard', function(item, attempts) {
+      assert(item.a === 'b');
+      assert(attempts === 2);
+      done();
+    });
+    queue.start();
+    queue.addItem({ a: 'b' });
+  });
+});
+
 describe('end-to-end', function() {
   var queue;
   beforeEach(function() {
@@ -179,7 +272,21 @@ describe('end-to-end', function() {
       done();
     };
     queue.start();
+    queue.addItem({ a: 'b' });
+  });
 
+  it('should run end-to-end async', function(done) {
+    queue.fn = function(item, cb) {
+      setTimeout(function() {
+        cb();
+      }, 1000);
+    };
+    queue.on('success', function() {
+      done();
+    });
+
+    queue.start();
     queue.addItem({ a: 'b' });
   });
 });
+


### PR DESCRIPTION
Adds support for overriding retry logic and observing message successes, errors, and discards via events.

... which allows us to:

- incorporate complete E2E tests in analytics.js core prior to rolling out the "localstorage write ahead log" by default :) https://github.com/segment-integrations/analytics.js-integration-segmentio/pull/23
- optionally add some logic to ajs to stop retrying either after a certain time or number of attempts

@tsholmes 