### PR TITLE
default to empty queues

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -141,7 +141,7 @@ Queue.prototype.requeue = function(item, attemptNumber, error) {
 };
 
 Queue.prototype._enqueue = function(entry) {
-  var queue = this._store.queue.get();
+  var queue = this._store.queue.get() || [];
   queue.push(entry);
   queue = queue.sort(function(a,b) {
     return a.time - b.time;
@@ -161,8 +161,8 @@ Queue.prototype._processHead = function() {
   this._schedule.cancel(this._processId);
 
   // Pop the head off the queue
-  var queue = store.queue.get();
-  var inProgress = store.inProgress.get();
+  var queue = store.queue.get() || [];
+  var inProgress = store.inProgress.get() || {};
   var now = this._schedule.now();
   var toRun = [];
 


### PR DESCRIPTION
In internal-only production testing, we're seeing extremely intermittent (>3 users in thousands) cases where the browser has localstorage enabled, but after some period of browsing the queue does not exist in localstorage, likely owing to either it having been already reclaimed by another page or the user doing a hard refresh. We want to prime fresh, empty queues in these cases!

@tsholmes 