### PR TITLE
Support (configurable) exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ var options = {
   reclaimWait: 500,      // (.5s)
   minRetryDelay: 1000,   // min retry delay in ms (used in exp. backoff calcs)
   maxRetryDelay: 30000,  // max retry delay in ms (used in exp. backoff calcs)
-  backoffFactor: 2,      // exponential backoff factor (^2)
-  backoffJitter: 0,      // jitter factor for backoff calcs
-  maxItems: 100          // queue high water mark
+  backoffFactor: 2,      // exponential backoff factor (attempts^n)
+  backoffJitter: 0,      // jitter factor for backoff calcs (0 is usually fine)
+  maxItems: Infinity     // queue high water mark (we suggest 100 as a max)
 };
 
 var queue = new Queue('my_queue_name', opts, (item, done) => {

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ queue.addItem({ a: 'b' });
 
 Can be overridden to provide a custom retry delay in ms. You'll likely want to use the queue instance's backoff constants here.
 
-```
+```js
 this.backoff = {
   MIN_RETRY_DELAY: opts.minRetryDelay || 1000,
   MAX_RETRY_DELAY: opts.maxRetryDelay || 30000,
@@ -101,11 +101,7 @@ queue.getDelay = function(attemptNumber) {
 
 ### .shouldRetry `(item, attemptNumber, error) -> boolean`
 
-Can be overridden to provide custom logic for whether to requeue the item. You'll likely want to use the queue instance's maxAttempts constant here.
-
-```
-this.maxAttempts = opts.maxAttempts || Infinity
-```
+Can be overridden to provide custom logic for whether to requeue the item. You'll likely want to use the queue instance's `maxAttempts` variable (which is overridable via constructor's `opts` argument).
 
 **Default**:
 ```js
@@ -115,14 +111,16 @@ queue.shouldRetry = function(item, attemptNumber, error) {
 };
 ```
 
+You may also want to selectively retry based on error returned by your process function or something in the item itself.
+
 **Override Example**:
 ```javascript
 queue.shouldRetry = function(item, attemptNumber, error) {
+  // max attempts
+  if (attemptNumber > this.maxAttempts) return false;
+
   // based on something in the item itself
   if (new Date(item.timestamp) - new Date() > 86400000) return false;
-
-  // max attempts
-  if (attemptNumber > 3) return false;
 
   // selective error handling
   if (error.code === '429') return false;

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # localstorage-retry
 [![Circle CI](https://circleci.com/gh/segmentio/localstorage-retry.svg?style=shield&circle-token=26daea4c3c8e5645f15841fdda51f14386bc5302)](https://circleci.com/gh/segmentio/localstorage-retry)
 
-Provides durable retries with a queue held in `localStorage`
+Provides durable retries with a queue held in `localStorage` (with graceful fallbacks to memory when necessary).
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ var options = {
   backoffFactor: 2,      // exponential backoff factor (attempts^n)
   backoffJitter: 0,      // jitter factor for backoff calcs (0 is usually fine)
   maxItems: Infinity     // queue high water mark (we suggest 100 as a max)
+  maxAttempts: Infinity  // max retry attempts before discarding
 };
 
 var queue = new Queue('my_queue_name', opts, (item, done) => {
@@ -100,8 +101,21 @@ queue.getDelay = function(attemptNumber) {
 
 ### .shouldRetry `(item, attemptNumber, error) -> boolean`
 
-Can be overridden to provide custom logic for whether to requeue the item. (Defaults to `true`.)
+Can be overridden to provide custom logic for whether to requeue the item. You'll likely want to use the queue instance's maxAttempts constant here.
 
+```
+this.maxAttempts = opts.maxAttempts || Infinity
+```
+
+**Default**:
+```js
+queue.shouldRetry = function(item, attemptNumber, error) {
+  if (attemptNumber > this.maxAttempts) return false;
+  return true;
+};
+```
+
+**Override Example**:
 ```javascript
 queue.shouldRetry = function(item, attemptNumber, error) {
   // based on something in the item itself

--- a/README.md
+++ b/README.md
@@ -38,10 +38,6 @@ The queue can be initialized with the following options (*defaults shown*):
 
 ```js
 var options = {
-  ackTimer: 1000,        // ack interval in ms
-  reclaimTimer: 3000,    // (3s)
-  reclaimTimeout: 10000, // (10s)
-  reclaimWait: 500,      // (.5s)
   minRetryDelay: 1000,   // min retry delay in ms (used in exp. backoff calcs)
   maxRetryDelay: 30000,  // max retry delay in ms (used in exp. backoff calcs)
   backoffFactor: 2,      // exponential backoff factor (attempts^n)

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ function Queue(name, opts, fn) {
   this.name = name;
   this.id = uuid();
   this.fn = fn;
-  this.maxItems = opts.maxItems || 100;
+  this.maxItems = opts.maxItems || Infinity;
 
   this.timeouts = {
     ACK_TIMER: opts.ackTimer || 1000,
@@ -218,6 +218,7 @@ Queue.prototype._processHead = function() {
       }
     });
   }
+
   store.set(this.keys.QUEUE, queue);
   store.set(this.keys.IN_PROGRESS, inProgress);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,17 +29,25 @@ function bind(func, obj) {
  * @param {String} name The name of the queue. Will be used to find abandoned queues and retry their items
  * @param {processFunc} fn The function to call in order to process an item added to the queue
  */
-function Queue(name, fn) {
+function Queue(name, opts, fn) {
+  if (typeof opts === 'function') fn = opts;
   this.name = name;
   this.id = uuid();
   this.fn = fn;
+  this.maxItems = opts.maxItems || 100;
 
   this.timeouts = {
-    ACK_TIMER: 1000,
-    RECLAIM_TIMER: 3000,
-    RECLAIM_TIMEOUT: 10000,
-    RECLAIM_WAIT: 500,
-    MAX_QUEUE_DELAY: 30000
+    ACK_TIMER: opts.ackTimer || 1000,
+    RECLAIM_TIMER: opts.reclaimTimer || 3000,
+    RECLAIM_TIMEOUT: opts.reclaimTimeout || 10000,
+    RECLAIM_WAIT: opts.reclaimWait || 500
+  };
+
+  this.backoff = {
+    MIN_RETRY_DELAY: opts.minRetryDelay || 1000,
+    MAX_RETRY_DELAY: opts.maxRetryDelay || 30000,
+    FACTOR: opts.backoffFactor || 2,
+    JITTER: opts.backoffJitter || 0
   };
 
   this.keys = {
@@ -112,7 +120,17 @@ Queue.prototype.shouldRetry = function() {
  * @return {Number} The delay in milliseconds to wait before attempting a retry
  */
 Queue.prototype.getDelay = function(attemptNumber) {
-  return 1000 * Math.pow(attemptNumber, 2);
+  var ms = this.backoff.MIN_RETRY_DELAY * Math.pow(this.backoff.FACTOR, attemptNumber);
+  if (this.backoff.JITTER) {
+    var rand =  Math.random();
+    var deviation = Math.floor(rand * this.backoff.JITTER * ms);
+    if (Math.floor(rand * 10) < 5) {
+      ms -= deviation;
+    } else {
+      ms += deviation;
+    }
+  }
+  return Number(Math.min(ms, this.backoff.MAX_RETRY_DELAY).toPrecision(1));
 };
 
 /**
@@ -136,12 +154,11 @@ Queue.prototype.addItem = function(item) {
  * @param {Error} [error] The error from previous attempt, if there was one
  */
 Queue.prototype.requeue = function(item, attemptNumber, error) {
-  var delay = Math.min(this.getDelay(attemptNumber), this.timeouts.MAX_QUEUE_DELAY);
   if (this.shouldRetry(item, attemptNumber, error)) {
     this._enqueue({
       item: item,
       attemptNumber: attemptNumber,
-      time: this._schedule.now() + delay
+      time: this._schedule.now() + this.getDelay(attemptNumber)
     });
   } else {
     this.emit('discard', item, attemptNumber);
@@ -150,10 +167,12 @@ Queue.prototype.requeue = function(item, attemptNumber, error) {
 
 Queue.prototype._enqueue = function(entry) {
   var queue = this._store.get(this.keys.QUEUE) || [];
+  queue = queue.slice(-(this.maxItems - 1));
   queue.push(entry);
   queue = queue.sort(function(a,b) {
     return a.time - b.time;
   });
+
   this._store.set(this.keys.QUEUE, queue);
 
   if (this._running) {
@@ -276,6 +295,7 @@ Queue.prototype._reclaim = function(id) {
   var our = {
     queue: this._store.get(this.keys.QUEUE) || []
   };
+
   var their = {
     inProgress: other.get(this.keys.IN_PROGRESS) || {},
     queue: other.get(this.keys.QUEUE) || []

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,18 +37,19 @@ function Queue(name, opts, fn) {
   this.maxItems = opts.maxItems || Infinity;
   this.maxAttempts = opts.maxAttempts || Infinity;
 
-  this.timeouts = {
-    ACK_TIMER: opts.ackTimer || 1000,
-    RECLAIM_TIMER: opts.reclaimTimer || 3000,
-    RECLAIM_TIMEOUT: opts.reclaimTimeout || 10000,
-    RECLAIM_WAIT: opts.reclaimWait || 500
-  };
-
   this.backoff = {
     MIN_RETRY_DELAY: opts.minRetryDelay || 1000,
     MAX_RETRY_DELAY: opts.maxRetryDelay || 30000,
     FACTOR: opts.backoffFactor || 2,
     JITTER: opts.backoffJitter || 0
+  };
+
+  // painstakingly tuned. that's why they're not "easily" configurable
+  this.timeouts = {
+    ACK_TIMER: 1000,
+    RECLAIM_TIMER: 3000,
+    RECLAIM_TIMEOUT: 10000,
+    RECLAIM_WAIT: 500
   };
 
   this.keys = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ function Queue(name, opts, fn) {
   this.id = uuid();
   this.fn = fn;
   this.maxItems = opts.maxItems || Infinity;
+  this.maxAttempts = opts.maxAttempts || Infinity;
 
   this.timeouts = {
     ACK_TIMER: opts.ackTimer || 1000,
@@ -109,7 +110,8 @@ Queue.prototype.stop = function() {
  * @param {Error} error The error from previous attempt, if there was one
  * @return {Boolean} Whether to requeue the message
  */
-Queue.prototype.shouldRetry = function() {
+Queue.prototype.shouldRetry = function(_, attemptNumber) {
+  if (attemptNumber > this.maxAttempts) return false;
   return true;
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -111,6 +111,17 @@ describe('Queue', function() {
     assert(queue.fn.notCalled);
   });
 
+  it('should respect maxItems', function() {
+    for (var i = 0; i < 105; i++) {
+      queue.addItem(i);
+    }
+
+    var _queue = queue._store.get(queue.keys.QUEUE);
+    assert.equal(_queue.length, 100);
+    assert.equal(_queue[0].item, 5);
+    assert.equal(_queue[99].item, 104);
+  });
+
   it('should take over a queued task if a queue is abandoned', function() {
     // a wild queue of interest appears
     var foundQueue = new Store('test', 'fake-id', queue.keys);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -113,6 +113,7 @@ describe('Queue', function() {
 
   it('should respect maxItems', function() {
     for (var i = 0; i < 105; i++) {
+      clock.tick(1);
       queue.addItem(i);
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -112,6 +112,8 @@ describe('Queue', function() {
   });
 
   it('should respect maxItems', function() {
+    queue.maxItems = 100;
+
     for (var i = 0; i < 105; i++) {
       clock.tick(1);
       queue.addItem(i);

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -18,7 +18,7 @@ describe('Store', function() {
 
   beforeEach(function() {
     engine.clear();
-    store = new Store('name', 'id', keys, engine);
+    store = new Store('name', 'id', keys);
   });
 
   describe('.get', function() {


### PR DESCRIPTION
This PR does a few thing:

- allows library user to explicitly override default behaviors for timeouts, retry behavior, and queue size
- makes the default retry delay logic a bit smarter, factoring in jitter if passed in as an option and respecting configurable factor (using logic from [segmentio/backo](https://github.com/segmentio/backo))
- respects new `maxItems` option, removing still-queued tasks oldest first
- respects new `maxAttempts` option, discarding after exceeded

All defaults are maintained; this is a nonbreaking change.

