### PR TITLE
Fix data loss when adding multiple items

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -196,18 +196,7 @@ Queue.prototype._processHead = function() {
   var now = this._schedule.now();
   var toRun = [];
 
-  while (queue.length && queue[0].time <= now) {
-    var el = queue.shift();
-
-    var id = uuid();
-
-    // Save this to the in progress map
-    inProgress[id] = {
-      item: el.item,
-      attemptNumber: el.attemptNumber,
-      time: this._schedule.now()
-    };
-
+  function enqueue(el, id) {
     toRun.push({
       item: el.item,
       done: function handle(err, res) {
@@ -220,6 +209,20 @@ Queue.prototype._processHead = function() {
         }
       }
     });
+  }
+
+  while (queue.length && queue[0].time <= now) {
+    var el = queue.shift();
+    var id = uuid();
+
+    // Save this to the in progress map
+    inProgress[id] = {
+      item: el.item,
+      attemptNumber: el.attemptNumber,
+      time: self._schedule.now()
+    };
+
+    enqueue(el, id);
   }
 
   store.set(this.keys.QUEUE, queue);


### PR DESCRIPTION
```js
const queue = new Queue(
    'test',
    {maxAttempts: 10}
    (item, done) =>
        fetch(...)
            .then(data => done(null, data))
            .catch(err => done(err))
)

for(let i = 0; i < 100; i++)
    queue.addItem('test-item ' + i)

queue.start()
```

In this example if any items fails one time it will be permanently removed from the queue and the last item (`test-item 99`) will be retried instead. This means that each item is tried only one time, except `test-item 99` which will be retired 101 times. This also causes an overflow of the `toProgress` queue because `maxAttempts` isn't incremented on the last item.

This is caused by how block-scoping works with `var` : 

https://github.com/segmentio/localstorage-retry/blob/6546c4cd3f960824605cf316453b73fb51780a86/lib/index.js#L199-L202

```js
  while (queue.length && queue[0].time <= now) {
    var el = queue.shift();
    var id = uuid();

    // Save this to the in progress map
    inProgress[id] = {
      item: el.item,
      attemptNumber: el.attemptNumber,
      time: this._schedule.now()
    };

    toRun.push({
      item: el.item,
      done: function handle(err, res) {
        // <========
       // here `id` is the id of the last item, same for el

        var inProgress = store.get(self.keys.IN_PROGRESS) || {};
        delete inProgress[id];
        store.set(self.keys.IN_PROGRESS, inProgress);
        self.emit('processed', err, res, el.item);
        if (err) {
          self.requeue(el.item, el.attemptNumber + 1, err);
        }
      }
    });
  }
```

It's the same as 

```js
  var el, id;

  while (queue.length && queue[0].time <= now) {
    el = queue.shift();
    id = uuid();
```

---

Partially fixes https://segment.atlassian.net/browse/LIB-359, I think `toProgress` can still overflow when the queue is reclaimed.

cc @f2prateek 