### PR TITLE
Remove IE 7 and IE 8

### DIFF
--- a/karma.conf.ci.js
+++ b/karma.conf.ci.js
@@ -33,16 +33,6 @@ var customLaunchers = {
     browserName: 'safari',
     version: '9.0'
   },
-  sl_ie_7: {
-    base: 'SauceLabs',
-    browserName: 'internet explorer',
-    version: '7'
-  },
-  sl_ie_8: {
-    base: 'SauceLabs',
-    browserName: 'internet explorer',
-    version: '8'
-  },
   sl_ie_9: {
     base: 'SauceLabs',
     browserName: 'internet explorer',


### PR DESCRIPTION
IE 7 has been dropped by Sauce and IE 8 by Karma. Needed to get CI running (https://circleci.com/gh/segmentio/localstorage-retry/93)