### PR TITLE
removed window object references from lib/schedule.js

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -4,12 +4,12 @@ var each = require('@ndhoule/each');
 
 var defaultClock = {
   setTimeout: function(fn, ms) {
-    return window.setTimeout(fn, ms);
+    return setTimeout(fn, ms);
   },
   clearTimeout: function(id) {
-    return window.clearTimeout(id);
+    return clearTimeout(id);
   },
-  Date: window.Date
+  Date: Date
 };
 
 var clock = defaultClock;


### PR DESCRIPTION
Tested locally if removing the `window` object from the `lib/schedule.js` would work, and the tests ran fine as well as my own app tests.