### PR TITLE
#16 Re order keys to delete ack last

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,9 +55,9 @@ function Queue(name, opts, fn) {
   this.keys = {
     IN_PROGRESS: 'inProgress',
     QUEUE: 'queue',
-    ACK: 'ack',
     RECLAIM_START: 'reclaimStart',
-    RECLAIM_END: 'reclaimEnd'
+    RECLAIM_END: 'reclaimEnd',
+    ACK: 'ack'
   };
 
   this._schedule = new Schedule();
@@ -335,11 +335,11 @@ Queue.prototype._reclaim = function(id) {
   this._store.set(this.keys.QUEUE, our.queue);
 
   // remove all keys
-  other.remove(this.keys.ACK);
-  other.remove(this.keys.RECLAIM_START);
-  other.remove(this.keys.RECLAIM_END);
   other.remove(this.keys.IN_PROGRESS);
   other.remove(this.keys.QUEUE);
+  other.remove(this.keys.RECLAIM_START);
+  other.remove(this.keys.RECLAIM_END);
+  other.remove(this.keys.ACK);
 
   // process the new items we claimed
   this._processHead();


### PR DESCRIPTION
From the ticket: 
> There are two places where `ack` can be deleted:
> 
>     1. When switching to in memory,
> 
>     2. When a queue is reclaimed.
> 
> 
> In a small percentage of cases, browsers delete some of the keys, but not all.
> `ack` should always be deleted last other wise the queue cannot be cleaned up later if only half processed.