### PR TITLE
Pass the error object to discard event

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ queue.on('processed', function(err, res, item) {
 ### `discard`
 
 ```javascript
-queue.on('discard', function(item, attempts) {
-  console.error('discarding message %O after %d attempts', item, attempts);
+queue.on('discard', function(item, attempts, error) {
+  console.error('discarding message %O after %d attempts with last known error %O', item, attempts, error);
 })
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -145,7 +145,8 @@ Queue.prototype.addItem = function(item) {
   this._enqueue({
     item: item,
     attemptNumber: 0,
-    time: this._schedule.now()
+    time: this._schedule.now(),
+    error: null
   });
 };
 
@@ -161,10 +162,11 @@ Queue.prototype.requeue = function(item, attemptNumber, error) {
     this._enqueue({
       item: item,
       attemptNumber: attemptNumber,
-      time: this._schedule.now() + this.getDelay(attemptNumber)
+      time: this._schedule.now() + this.getDelay(attemptNumber),
+      error: error
     });
   } else {
-    this.emit('discard', item, attemptNumber);
+    this.emit('discard', item, attemptNumber, error);
   }
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -344,9 +344,10 @@ describe('events', function() {
     queue.shouldRetry = function(item, attemptNumber) {
       return attemptNumber < 2;
     };
-    queue.on('discard', function(item, attempts) {
+    queue.on('discard', function(item, attempts, error) {
       assert.equal(item.a, 'b');
       assert.equal(attempts, 2);
+      assert.equal(error.message, 'no');
       done();
     });
     queue.start();


### PR DESCRIPTION
Presently, the **discard** event is only passing the number of attempts and the original item.

This PR passes the error object which is used in the requeue callback. This will allow consumers of the library to peak into the error and implement custom logic if they require.