### PR TITLE
Inmemory reclaim #23

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -33,7 +33,7 @@ var inMemoryStore = {
   }
 };
 
-function isSupportedNatively() {
+var isSupportedNatively = (function() {
   try {
     if (!window.localStorage) return false;
     var key = uuid();
@@ -47,17 +47,17 @@ function isSupportedNatively() {
     // Can throw if localStorage is disabled
     return false;
   }
-}
+}());
 
 function pickStorage() {
-  if (isSupportedNatively()) {
+  if (isSupportedNatively) {
     return window.localStorage;
   }
   // fall back to in-memory
   return inMemoryStore;
 }
 
-function isReadSupportedNatively() {
+var isReadSupportedNatively = (function() {
   try {
     if (!window.localStorage) return false;
     var key = window.localStorage.key(0);
@@ -69,10 +69,10 @@ function isReadSupportedNatively() {
     // Can throw if localStorage is disabled
     return false;
   }
-}
+}());
 
 function pickReclaimStorage() {
-  if (isReadSupportedNatively()) {
+  if (isSupportedNatively || isReadSupportedNatively) {
     return window.localStorage;
   }
   // fall back to in-memory

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -57,7 +57,30 @@ function pickStorage() {
   return inMemoryStore;
 }
 
+function isReadSupportedNatively() {
+  try {
+    if (!window.localStorage) return false;
+    var key = window.localStorage.key(0);
+    window.localStorage.getItem(key);
+
+    // Ensure access of removeItem does not throw errors
+    return typeof window.localStorage.removeItem === 'function';
+  } catch (e) {
+    // Can throw if localStorage is disabled
+    return false;
+  }
+}
+
+function pickReclaimStorage() {
+  if (isReadSupportedNatively()) {
+    return window.localStorage;
+  }
+  // fall back to in-memory
+  return inMemoryStore;
+}
+
 // Return a shared instance
 module.exports.defaultEngine = pickStorage();
+module.exports.reclaimEngine = pickReclaimStorage();
 // Expose the in-memory store explicitly for testing
 module.exports.inMemoryEngine = inMemoryStore;

--- a/lib/index.js
+++ b/lib/index.js
@@ -280,7 +280,7 @@ Queue.prototype._checkReclaim = function() {
 
   function findOtherQueues(name) {
     var res = [];
-    var storage = self._store.getOriginalEngine();
+    var storage = self._store.getReclaimEngine();
     for (var i = 0; i < storage.length; i++) {
       var k = storage.key(i);
       var parts = k.split('.');

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var defaultEngine = require('./engine').defaultEngine;
+var reclaimEngine = require('./engine').reclaimEngine;
 var inMemoryEngine = require('./engine').inMemoryEngine;
 var each = require('@ndhoule/each');
 var keys = require('@ndhoule/keys');
@@ -15,7 +16,7 @@ function Store(name, id, keys, optionalEngine) {
   this.name = name;
   this.keys = keys || {};
   this.engine = optionalEngine || defaultEngine;
-  this.originalEngine = this.engine;
+  this.reclaimEngine = optionalEngine || reclaimEngine;
 }
 
 /**
@@ -57,8 +58,8 @@ Store.prototype.get = function(key) {
  * Get original engine
  */
 
-Store.prototype.getOriginalEngine = function() {
-  return this.originalEngine;
+Store.prototype.getReclaimEngine = function() {
+  return this.reclaimEngine;
 };
 
 /**

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var defaultEngine = require('../lib/engine').defaultEngine;
+var reclaimEngine = require('../lib/engine').reclaimEngine;
 var inMemoryEngine = require('../lib/engine').inMemoryEngine;
 var assert = require('proclaim');
 
@@ -35,6 +36,28 @@ describe('localStorage', function() {
   describe('when not supported', function() {
     beforeEach(function() {
       engine = inMemoryEngine;
+      engine.clear();
+    });
+
+    it('should function', function() {
+      engine.setItem('test-key', 'abc');
+      assert.strictEqual(engine.getItem('test-key'), 'abc');
+      assert.strictEqual(engine.length, 1);
+      assert.strictEqual(engine.key(0), 'test-key');
+
+      engine.removeItem('test-key');
+      assert.strictEqual(engine.getItem('test-key'), null);
+      assert.strictEqual(engine.length, 0);
+
+      engine.setItem('test-key', 'abc');
+      engine.clear();
+      assert.strictEqual(engine.length, 0);
+    });
+  });
+
+  describe('when using reclaimEngine', function() {
+    beforeEach(function() {
+      engine = reclaimEngine;
       engine.clear();
     });
 

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -86,10 +86,10 @@ describe('Store', function() {
       assert.strictEqual(store.engine, inMemoryEngine);
     });
 
-    it('should not switch the original storage mechanism', function() {
-      assert.strictEqual(store.getOriginalEngine(), engine);
+    it('should not switch the reclaim storage mechanism', function() {
+      assert.strictEqual(store.getReclaimEngine(), engine);
       store._swapEngine();
-      assert.strictEqual(store.getOriginalEngine(), engine);
+      assert.strictEqual(store.getReclaimEngine(), engine);
     });
 
     it('should swap upon quotaExceeded on set', function() {


### PR DESCRIPTION
This allows us to keep a reference to localstorage for reclaim purposes even when localstorage is full.

Carrying on from #20

When creating an instance of localstorage-retry, Store will grab the defaultEngine and use this for the originalEngine which is used to drive the reclaim mechanism

My assumption inside of the last PR was that defaultEngine would always be localstorage. However, engine runs a check and assigns the store to localstorage or inmemory before the module is resolved.

This means, if localstorage is so full that we cant insert a uuid and "test_value", then we will only ever run reclaim against the inmemory engine.