### PR TITLE
#27 Prevent reclaim from running if host computer is running slow

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -256,7 +256,7 @@ Queue.prototype._ack = function() {
   this._store.set(this.keys.ACK, this._schedule.now());
   this._store.set(this.keys.RECLAIM_START, null);
   this._store.set(this.keys.RECLAIM_END, null);
-  this._schedule.run(this._ack, this.timeouts.ACK_TIMER);
+  this._schedule.run(this._ack, this.timeouts.ACK_TIMER, Schedule.MODES.ASAP);
 };
 
 Queue.prototype._checkReclaim = function() {
@@ -274,8 +274,8 @@ Queue.prototype._checkReclaim = function() {
         if (store.get(self.keys.RECLAIM_END) !== self.id) return;
         if (store.get(self.keys.RECLAIM_START) !== self.id) return;
         self._reclaim(store.id);
-      }, self.timeouts.RECLAIM_WAIT, true, false);
-    }, self.timeouts.RECLAIM_WAIT, true, false);
+      }, self.timeouts.RECLAIM_WAIT, Schedule.MODES.ABANDON);
+    }, self.timeouts.RECLAIM_WAIT, Schedule.MODES.ABANDON);
   }
 
   function findOtherQueues(name) {
@@ -298,7 +298,7 @@ Queue.prototype._checkReclaim = function() {
     tryReclaim(store);
   }, findOtherQueues(this.name));
 
-  this._schedule.run(this._checkReclaim, this.timeouts.RECLAIM_TIMER, true, true);
+  this._schedule.run(this._checkReclaim, this.timeouts.RECLAIM_TIMER, Schedule.MODES.RESCHEDULE);
 };
 
 Queue.prototype._reclaim = function(id) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -274,8 +274,8 @@ Queue.prototype._checkReclaim = function() {
         if (store.get(self.keys.RECLAIM_END) !== self.id) return;
         if (store.get(self.keys.RECLAIM_START) !== self.id) return;
         self._reclaim(store.id);
-      }, self.timeouts.RECLAIM_WAIT);
-    }, self.timeouts.RECLAIM_WAIT);
+      }, self.timeouts.RECLAIM_WAIT, true, false);
+    }, self.timeouts.RECLAIM_WAIT, true, false);
   }
 
   function findOtherQueues(name) {
@@ -298,7 +298,7 @@ Queue.prototype._checkReclaim = function() {
     tryReclaim(store);
   }, findOtherQueues(this.name));
 
-  this._schedule.run(this._checkReclaim, this.timeouts.RECLAIM_TIMER);
+  this._schedule.run(this._checkReclaim, this.timeouts.RECLAIM_TIMER, true, true);
 };
 
 Queue.prototype._reclaim = function(id) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -247,7 +247,7 @@ Queue.prototype._processHead = function() {
   queue = store.get(this.keys.QUEUE) || [];
   this._schedule.cancel(this._processId);
   if (queue.length > 0) {
-    this._processId = this._schedule.run(this._processHead, queue[0].time - now);
+    this._processId = this._schedule.run(this._processHead, queue[0].time - now, Schedule.Modes.ASAP);
   }
 };
 
@@ -256,7 +256,7 @@ Queue.prototype._ack = function() {
   this._store.set(this.keys.ACK, this._schedule.now());
   this._store.set(this.keys.RECLAIM_START, null);
   this._store.set(this.keys.RECLAIM_END, null);
-  this._schedule.run(this._ack, this.timeouts.ACK_TIMER, Schedule.MODES.ASAP);
+  this._schedule.run(this._ack, this.timeouts.ACK_TIMER, Schedule.Modes.ASAP);
 };
 
 Queue.prototype._checkReclaim = function() {
@@ -274,8 +274,8 @@ Queue.prototype._checkReclaim = function() {
         if (store.get(self.keys.RECLAIM_END) !== self.id) return;
         if (store.get(self.keys.RECLAIM_START) !== self.id) return;
         self._reclaim(store.id);
-      }, self.timeouts.RECLAIM_WAIT, Schedule.MODES.ABANDON);
-    }, self.timeouts.RECLAIM_WAIT, Schedule.MODES.ABANDON);
+      }, self.timeouts.RECLAIM_WAIT, Schedule.Modes.ABANDON);
+    }, self.timeouts.RECLAIM_WAIT, Schedule.Modes.ABANDON);
   }
 
   function findOtherQueues(name) {
@@ -298,7 +298,7 @@ Queue.prototype._checkReclaim = function() {
     tryReclaim(store);
   }, findOtherQueues(this.name));
 
-  this._schedule.run(this._checkReclaim, this.timeouts.RECLAIM_TIMER, Schedule.MODES.RESCHEDULE);
+  this._schedule.run(this._checkReclaim, this.timeouts.RECLAIM_TIMER, Schedule.Modes.RESCHEDULE);
 };
 
 Queue.prototype._reclaim = function(id) {

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -2,6 +2,8 @@
 
 var each = require('@ndhoule/each');
 
+var CLOCK_LATE_FACTOR = 2;
+
 var defaultClock = {
   setTimeout: function(fn, ms) {
     return window.setTimeout(fn, ms);
@@ -23,9 +25,9 @@ Schedule.prototype.now = function() {
   return +new clock.Date();
 };
 
-Schedule.prototype.run = function(task, timeout) {
+Schedule.prototype.run = function(task, timeout, dontExecuteIfLate, rescheduleIfLate) {
   var id = this.nextId++;
-  this.tasks[id] = clock.setTimeout(this._handle(id, task), timeout);
+  this.tasks[id] = clock.setTimeout(this._handle(id, task, timeout, dontExecuteIfLate, rescheduleIfLate), timeout);
   return id;
 };
 
@@ -41,10 +43,17 @@ Schedule.prototype.cancelAll = function() {
   this.tasks = {};
 };
 
-Schedule.prototype._handle = function(id, callback) {
+Schedule.prototype._handle = function(id, callback, timeout, dontExecuteIfLate, rescheduleIfLate) {
   var self = this;
+  var start = self.now();
   return function() {
     delete self.tasks[id];
+    if (dontExecuteIfLate && start + timeout * CLOCK_LATE_FACTOR < self.now()) {
+      if (rescheduleIfLate) {
+        self.run(callback, timeout, dontExecuteIfLate, rescheduleIfLate);
+      }
+      return;
+    }
     return callback();
   };
 };

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -73,6 +73,6 @@ Schedule.resetClock = function() {
   clock = defaultClock;
 };
 
-Schedule.MODES = modes;
+Schedule.Modes = modes;
 
 module.exports = Schedule;

--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -16,6 +16,12 @@ var defaultClock = {
 
 var clock = defaultClock;
 
+var modes = {
+  ASAP: 1,
+  RESCHEDULE: 2,
+  ABANDON: 3
+};
+
 function Schedule() {
   this.tasks = {};
   this.nextId = 1;
@@ -25,9 +31,10 @@ Schedule.prototype.now = function() {
   return +new clock.Date();
 };
 
-Schedule.prototype.run = function(task, timeout, dontExecuteIfLate, rescheduleIfLate) {
+Schedule.prototype.run = function(task, timeout, mode) {
   var id = this.nextId++;
-  this.tasks[id] = clock.setTimeout(this._handle(id, task, timeout, dontExecuteIfLate, rescheduleIfLate), timeout);
+
+  this.tasks[id] = clock.setTimeout(this._handle(id, task, timeout, mode || modes.ASAP), timeout);
   return id;
 };
 
@@ -43,14 +50,14 @@ Schedule.prototype.cancelAll = function() {
   this.tasks = {};
 };
 
-Schedule.prototype._handle = function(id, callback, timeout, dontExecuteIfLate, rescheduleIfLate) {
+Schedule.prototype._handle = function(id, callback, timeout, mode) {
   var self = this;
   var start = self.now();
   return function() {
     delete self.tasks[id];
-    if (dontExecuteIfLate && start + timeout * CLOCK_LATE_FACTOR < self.now()) {
-      if (rescheduleIfLate) {
-        self.run(callback, timeout, dontExecuteIfLate, rescheduleIfLate);
+    if (mode >= modes.RESCHEDULE && start + timeout * CLOCK_LATE_FACTOR < self.now()) {
+      if (mode === modes.RESCHEDULE) {
+        self.run(callback, timeout, mode);
       }
       return;
     }
@@ -65,5 +72,7 @@ Schedule.setClock = function(newClock) {
 Schedule.resetClock = function() {
   clock = defaultClock;
 };
+
+Schedule.MODES = modes;
 
 module.exports = Schedule;

--- a/test/schedule.test.js
+++ b/test/schedule.test.js
@@ -40,7 +40,7 @@ describe('Schedule', function() {
     it('should not call task if past duration factor', function() {
       var timeout = 500;
       var spyFn = sinon.spy();
-      schedule.run(spyFn, timeout, Schedule.MODES.ABANDON);
+      schedule.run(spyFn, timeout, Schedule.Modes.ABANDON);
       // Fast forwards time but doesnt trigger timers
       clock.setSystemTime(timeout * 2);
       // Trigger timers here
@@ -54,7 +54,7 @@ describe('Schedule', function() {
     it('should reschedule and call task if skipped', function() {
       var timeout = 500;
       var spyFn = sinon.spy();
-      schedule.run(spyFn, timeout, Schedule.MODES.RESCHEDULE);
+      schedule.run(spyFn, timeout, Schedule.Modes.RESCHEDULE);
       // Fast forwards time but doesnt trigger timers
       clock.setSystemTime(timeout * 2);
       // Trigger timers here

--- a/test/schedule.test.js
+++ b/test/schedule.test.js
@@ -31,7 +31,7 @@ describe('Schedule', function() {
     it('should call task after timeout even after long duration', function() {
       var timeout = 500;
       var spyFn = sinon.spy();
-      schedule.run(spyFn, timeout, false, false);
+      schedule.run(spyFn, timeout);
       clock.setSystemTime(timeout * 2);
       clock.tick(timeout);
       assert(spyFn.calledOnce);
@@ -40,7 +40,7 @@ describe('Schedule', function() {
     it('should not call task if past duration factor', function() {
       var timeout = 500;
       var spyFn = sinon.spy();
-      schedule.run(spyFn, timeout, true, false);
+      schedule.run(spyFn, timeout, Schedule.MODES.ABANDON);
       // Fast forwards time but doesnt trigger timers
       clock.setSystemTime(timeout * 2);
       // Trigger timers here
@@ -54,7 +54,7 @@ describe('Schedule', function() {
     it('should reschedule and call task if skipped', function() {
       var timeout = 500;
       var spyFn = sinon.spy();
-      schedule.run(spyFn, timeout, true, true);
+      schedule.run(spyFn, timeout, Schedule.MODES.RESCHEDULE);
       // Fast forwards time but doesnt trigger timers
       clock.setSystemTime(timeout * 2);
       // Trigger timers here

--- a/test/schedule.test.js
+++ b/test/schedule.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var lolex = require('lolex');
+var assert = require('proclaim');
+var sinon = require('sinon');
+var Schedule = require('../lib/schedule');
+
+describe('Schedule', function() {
+  var clock;
+  var schedule;
+
+  beforeEach(function() {
+    clock = lolex.createClock(0);
+    Schedule.setClock(clock);
+    schedule = new Schedule();
+  });
+
+  afterEach(function() {
+    Schedule.resetClock();
+  });
+
+  describe('run', function() {
+    it('should call task after timeout', function() {
+      var timeout = 500;
+      var spyFn = sinon.spy();
+      schedule.run(spyFn, timeout);
+      clock.tick(timeout);
+      assert(spyFn.calledOnce);
+    });
+
+    it('should call task after timeout even after long duration', function() {
+      var timeout = 500;
+      var spyFn = sinon.spy();
+      schedule.run(spyFn, timeout, false, false);
+      clock.setSystemTime(timeout * 2);
+      clock.tick(timeout);
+      assert(spyFn.calledOnce);
+    });
+
+    it('should not call task if past duration factor', function() {
+      var timeout = 500;
+      var spyFn = sinon.spy();
+      schedule.run(spyFn, timeout, true, false);
+      // Fast forwards time but doesnt trigger timers
+      clock.setSystemTime(timeout * 2);
+      // Trigger timers here
+      clock.tick(timeout);
+      assert(spyFn.notCalled);
+      clock.tick(timeout);
+      // Ensure task is not rescheduled
+      assert(spyFn.notCalled);
+    });
+
+    it('should reschedule and call task if skipped', function() {
+      var timeout = 500;
+      var spyFn = sinon.spy();
+      schedule.run(spyFn, timeout, true, true);
+      // Fast forwards time but doesnt trigger timers
+      clock.setSystemTime(timeout * 2);
+      // Trigger timers here
+      clock.tick(timeout);
+      assert(spyFn.notCalled);
+      clock.tick(timeout);
+      assert(spyFn.calledOnce);
+    });
+  });
+});

--- a/test/schedule.test.js
+++ b/test/schedule.test.js
@@ -28,16 +28,16 @@ describe('Schedule', function() {
       assert(spyFn.calledOnce);
     });
 
-    it('should call task after timeout even after long duration', function() {
+    it('should call task ASAP after timeout even after long duration', function() {
       var timeout = 500;
       var spyFn = sinon.spy();
-      schedule.run(spyFn, timeout);
+      schedule.run(spyFn, timeout, Schedule.Modes.ASAP);
       clock.setSystemTime(timeout * 2);
       clock.tick(timeout);
       assert(spyFn.calledOnce);
     });
 
-    it('should not call task if past duration factor', function() {
+    it('should not call ABANDON task if past duration factor', function() {
       var timeout = 500;
       var spyFn = sinon.spy();
       schedule.run(spyFn, timeout, Schedule.Modes.ABANDON);
@@ -51,7 +51,16 @@ describe('Schedule', function() {
       assert(spyFn.notCalled);
     });
 
-    it('should reschedule and call task if skipped', function() {
+    it('should call ABANDON task if running on time', function() {
+      var timeout = 500;
+      var spyFn = sinon.spy();
+      schedule.run(spyFn, timeout, Schedule.Modes.ABANDON);
+
+      clock.tick(timeout);
+      assert(spyFn.calledOnce);
+    });
+
+    it('should RESCHEDULE and call task if skipped', function() {
       var timeout = 500;
       var spyFn = sinon.spy();
       schedule.run(spyFn, timeout, Schedule.Modes.RESCHEDULE);


### PR DESCRIPTION
This is one of two PRs in an attempt to fix duplication storms.

Essentially what we see is the reclaim process is able to run even when severely delayed, and sometimes this leads to multiple queues reclaiming one queue at a time. 

Our approach here is to prevent the reclaims from running if the host machine is under load