### PR TITLE
#27 Detect and remove duplicated tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ You can listen for `processed` events, which are emitted with each invocation of
 
 If a message is discarded entirely because it does not pass your `shouldRetry` logic upon attempted re-enqueuing, the queue will emit a `discard` event.
 
+If the queue is reclaiming events from an abandonded queue, and sees duplicate entries, we will keep the first, and discard the rest, emitting a `duplication` event for each.
+
 ### `processed`
 
 ```javascript
@@ -161,6 +163,14 @@ queue.on('processed', function(err, res, item) {
 ```javascript
 queue.on('discard', function(item, attempts) {
   console.error('discarding message %O after %d attempts', item, attempts);
+})
+```
+
+### `duplication`
+
+```javascript
+queue.on('duplication', function(item, attempts) {
+  console.error('discarding message %O due to duplicate entries', item, attempts);
 })
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function bind(func, obj) {
  *
  * @constructor
  * @param {String} name The name of the queue. Will be used to find abandoned queues and retry their items
- * @param {Object} opts Optional argument to override `maxItems`, `maxAttempts`, `minRetryDelay, `maxRetryDelay`, `backoffFactor` and `backoffJitter`.
+ * @param {Object} [opts] Optional argument to override `maxItems`, `maxAttempts`, `minRetryDelay, `maxRetryDelay`, `backoffFactor` and `backoffJitter`.
  * @param {processFunc} fn The function to call in order to process an item added to the queue
  */
 function Queue(name, opts, fn) {
@@ -157,7 +157,7 @@ Queue.prototype.addItem = function(item) {
  * @param {Mixed} item The item to retry
  * @param {Number} attemptNumber The attempt number (1 for first retry)
  * @param {Error} [error] The error from previous attempt, if there was one
- * @param {String} id The id of the queued message used for tracking duplicate entries
+ * @param {String} [id] The id of the queued message used for tracking duplicate entries
  */
 Queue.prototype.requeue = function(item, attemptNumber, error, id) {
   if (this.shouldRetry(item, attemptNumber, error)) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ function bind(func, obj) {
  *
  * @constructor
  * @param {String} name The name of the queue. Will be used to find abandoned queues and retry their items
+ * @param {Object} opts Optional argument to override `maxItems`, `maxAttempts`, `minRetryDelay, `maxRetryDelay`, `backoffFactor` and `backoffJitter`.
  * @param {processFunc} fn The function to call in order to process an item added to the queue
  */
 function Queue(name, opts, fn) {
@@ -156,13 +157,15 @@ Queue.prototype.addItem = function(item) {
  * @param {Mixed} item The item to retry
  * @param {Number} attemptNumber The attempt number (1 for first retry)
  * @param {Error} [error] The error from previous attempt, if there was one
+ * @param {String} id The id of the queued message used for tracking duplicate entries
  */
-Queue.prototype.requeue = function(item, attemptNumber, error) {
+Queue.prototype.requeue = function(item, attemptNumber, error, id) {
   if (this.shouldRetry(item, attemptNumber, error)) {
     this._enqueue({
       item: item,
       attemptNumber: attemptNumber,
-      time: this._schedule.now() + this.getDelay(attemptNumber)
+      time: this._schedule.now() + this.getDelay(attemptNumber),
+      id: id || uuid()
     });
   } else {
     this.emit('discard', item, attemptNumber);
@@ -206,7 +209,7 @@ Queue.prototype._processHead = function() {
         store.set(self.keys.IN_PROGRESS, inProgress);
         self.emit('processed', err, res, el.item);
         if (err) {
-          self.requeue(el.item, el.attemptNumber + 1, err);
+          self.requeue(el.item, el.attemptNumber + 1, err, el.id);
         }
       }
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -145,7 +145,8 @@ Queue.prototype.addItem = function(item) {
   this._enqueue({
     item: item,
     attemptNumber: 0,
-    time: this._schedule.now()
+    time: this._schedule.now(),
+    id: uuid()
   });
 };
 
@@ -310,23 +311,30 @@ Queue.prototype._reclaim = function(id) {
     queue: other.get(this.keys.QUEUE) || []
   };
 
+  var trackMessageIds = [];
+
+  var addConcatQueue = function(queue, incrementAttemptNumberBy) {
+    each(function(el) {
+      var id = el.id || uuid();
+      if (trackMessageIds.indexOf(id) >= 0) {
+        self.emit('duplication', el.item, el.attemptNumber);
+      } else {
+        our.queue.push({
+          item: el.item,
+          attemptNumber: el.attemptNumber + incrementAttemptNumberBy,
+          time: self._schedule.now(),
+          id: id
+        });
+        trackMessageIds.push(id);
+      }
+    }, queue);
+  };
+
   // add their queue to ours, resetting run-time to immediate and copying the attempt#
-  each(function(el) {
-    our.queue.push({
-      item: el.item,
-      attemptNumber: el.attemptNumber,
-      time: self._schedule.now()
-    });
-  }, their.queue);
+  addConcatQueue(their.queue, 0);
 
   // if the queue is abandoned, all the in-progress are failed. retry them immediately and increment the attempt#
-  each(function(el) {
-    our.queue.push({
-      item: el.item,
-      attemptNumber: el.attemptNumber + 1,
-      time: self._schedule.now()
-    });
-  }, their.inProgress);
+  addConcatQueue(their.inProgress, 1);
 
   our.queue = our.queue.sort(function(a,b) {
     return a.time - b.time;


### PR DESCRIPTION
If some tabs have duplicated events, we should have a way to remove them.

While this may not have immediate affect (A mix of old tabs running non-id checking localstorage and new tabs running this id checking) it is worth bringing this in incase we see more duplications coming from somewhere else in the future.

This isnt fool proof way of deduplicating as we are not getting all ids from our own queue or inProgress, but this at least prevents an exponential increase in events which is something we have noticed.